### PR TITLE
working custom stream schemas

### DIFF
--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -363,9 +363,12 @@ class mssqlConnector(SQLConnector):
         """Temp table from another table."""
 
         db_name, schema_name, table_name = self.parse_full_table_name(from_table_name)
-        full_table_name = f"{schema_name}.{table_name}" if schema_name else f"{table_name}"
-        tmp_full_table_name = f"{schema_name}.#{table_name}" if schema_name else f"#{table_name}"
-
+        full_table_name = (
+            f"{schema_name}.{table_name}" if schema_name else f"{table_name}"
+        )
+        tmp_full_table_name = (
+            f"{schema_name}.#{table_name}" if schema_name else f"#{table_name}"
+        )
 
         ddl = f"""
             SELECT TOP 0 *

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -156,8 +156,12 @@ class mssqlSink(SQLSink):
                 from_table_name=self.full_table_name
             )
 
-            db_name, schema_name, table_name = self.parse_full_table_name(self.full_table_name)
-            tmp_table_name = f"{schema_name}.#{table_name}" if schema_name else f"#{table_name}"
+            db_name, schema_name, table_name = self.parse_full_table_name(
+                self.full_table_name
+            )
+            tmp_table_name = (
+                f"{schema_name}.#{table_name}" if schema_name else f"#{table_name}"
+            )
             # Insert into temp table
             self.bulk_insert_records(
                 full_table_name=tmp_table_name,
@@ -233,7 +237,6 @@ class mssqlSink(SQLSink):
             self.connection.execute(f"SET IDENTITY_INSERT { to_table_name } OFF")
 
         self.connection.execute("COMMIT")
-
 
     def parse_full_table_name(
         self, full_table_name: str

--- a/target_mssql/tests/data_files/target_schema.singer
+++ b/target_mssql/tests/data_files/target_schema.singer
@@ -1,0 +1,4 @@
+{"type": "SCHEMA", "stream": "my_schema-table_in_custom_schema", "key_properties": ["id"], "schema": {"required": ["id", "metric"], "type": "object", "properties": {"id": {"type": "integer"}, "metric": {"type": "integer"}}}}
+{"type": "RECORD", "stream": "my_schema-table_in_custom_schema", "record": {"id": 1, "metric": 1}}
+{"type": "RECORD", "stream": "my_schema-table_in_custom_schema", "record": {"id": 2, "metric": 2}}
+{"type": "STATE", "value": {"table_in_custom_schema": 2}}

--- a/target_mssql/tests/test_core.py
+++ b/target_mssql/tests/test_core.py
@@ -194,3 +194,8 @@ def test_missing_value(mssql_target):
 def test_large_int(mssql_target):
     file_name = "large_int.singer"
     singer_file_to_target(file_name, mssql_target)
+
+
+def test_db_schema(mssql_target):
+    file_name = "target_schema.singer"
+    singer_file_to_target(file_name, mssql_target)


### PR DESCRIPTION
Getting schema from the first half of stream name takes a little extra engineering in SQL Server because temporary tables (which are used as part of the load) is prepended with a hash sign. Which means, in order to make a table temporary, the `full_table_name` must be split and reassembled with a hash as prefix to the table name part of the full table name.

In the future, it might be possible to clean this up by using the `as_temp_table` argument to the create table function. But for now, this works and tests pass.