### PR TITLE
Not create identity columns

### DIFF
--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -42,6 +42,7 @@ class mssqlConnector(SQLConnector):
         if primary_keys is None:
             primary_keys = self.key_properties
         partition_keys = partition_keys or None
+        
         self.connector.prepare_table(
             full_table_name=full_table_name,
             primary_keys=primary_keys,
@@ -112,13 +113,23 @@ class mssqlConnector(SQLConnector):
             if isinstance(columntype, sqlalchemy.types.VARCHAR) and is_primary_key:
                 columntype = sqlalchemy.types.VARCHAR(255)
 
-            columns.append(
-                sqlalchemy.Column(
-                    property_name,
-                    columntype,
-                    primary_key=is_primary_key,
+            if is_primary_key:
+                columns.append(
+                    sqlalchemy.Column(
+                        property_name,
+                        columntype,
+                        primary_key=True,
+                        autoincrement=False
+                    )
                 )
-            )
+            else:
+                columns.append(
+                    sqlalchemy.Column(
+                        property_name,
+                        columntype,
+                        primary_key=False
+                    )
+                )
 
         _ = sqlalchemy.Table(table_name, meta, *columns, schema=schema_name)
         meta.create_all(self._engine)

--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -42,7 +42,7 @@ class mssqlConnector(SQLConnector):
         if primary_keys is None:
             primary_keys = self.key_properties
         partition_keys = partition_keys or None
-        
+
         self.connector.prepare_table(
             full_table_name=full_table_name,
             primary_keys=primary_keys,
@@ -116,19 +116,12 @@ class mssqlConnector(SQLConnector):
             if is_primary_key:
                 columns.append(
                     sqlalchemy.Column(
-                        property_name,
-                        columntype,
-                        primary_key=True,
-                        autoincrement=False
+                        property_name, columntype, primary_key=True, autoincrement=False
                     )
                 )
             else:
                 columns.append(
-                    sqlalchemy.Column(
-                        property_name,
-                        columntype,
-                        primary_key=False
-                    )
+                    sqlalchemy.Column(property_name, columntype, primary_key=False)
                 )
 
         _ = sqlalchemy.Table(table_name, meta, *columns, schema=schema_name)

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -106,13 +106,7 @@ class mssqlSink(SQLSink):
                 insert_record[column.name] = record.get(column.name)
             insert_records.append(insert_record)
 
-        if self.key_properties and not is_temp_table:
-            self.connection.execute(f"SET IDENTITY_INSERT { full_table_name } ON")
-
         self.connection.execute(insert_sql, insert_records)
-
-        if self.key_properties and not is_temp_table:
-            self.connection.execute(f"SET IDENTITY_INSERT { full_table_name } OFF")
 
         if isinstance(records, list):
             return len(records)  # If list, we can quickly return record count.
@@ -231,14 +225,8 @@ class mssqlSink(SQLSink):
                 VALUES ({", ".join([f"temp.{key}" for key in schema["properties"].keys()])});
         """
 
-        if self.key_properties:
-            self.connection.execute(f"SET IDENTITY_INSERT { to_table_name } ON")
-
         self.connection.execute(merge_sql)
-
-        if self.key_properties:
-            self.connection.execute(f"SET IDENTITY_INSERT { to_table_name } OFF")
-
+        
         self.connection.execute("COMMIT")
 
     def parse_full_table_name(

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -72,7 +72,7 @@ class mssqlSink(SQLSink):
         full_table_name: str,
         schema: dict,
         records: Iterable[Dict[str, Any]],
-        is_temp_table: bool = False
+        is_temp_table: bool = False,
     ) -> Optional[int]:
         """Bulk insert records to an existing destination table.
         The default implementation uses a generic SQLAlchemy bulk insert operation.
@@ -226,7 +226,7 @@ class mssqlSink(SQLSink):
         """
 
         self.connection.execute(merge_sql)
-        
+
         self.connection.execute("COMMIT")
 
     def parse_full_table_name(

--- a/target_mssql/tests/data_files/null_key.singer
+++ b/target_mssql/tests/data_files/null_key.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "null_key", "schema": {"type": "object", "properties": { "id": {"type": ["string", "null"]}, "client_name": {"type": "string"} }}, "key_properties": ["id"]}
+{"type": "RECORD", "stream": "null_key", "record": {"id": "1", "client_name": "Gitter Windows Desktop App"}}
+{"type": "RECORD", "stream": "null_key", "record": {"id": "2", "client_name": "Gitter iOS App"}}

--- a/target_mssql/tests/data_files/simple_stream.singer
+++ b/target_mssql/tests/data_files/simple_stream.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "simple_stream", "schema": {"required": ["id"], "type": "object", "properties": { "id": {"type": ["string", "null"]}, "client_name": {"type": "string"} }}, "key_properties": ["id"]}
+{"type": "RECORD", "stream": "simple_stream", "record": {"id": "1", "client_name": "Gitter Windows Desktop App"}}
+{"type": "RECORD", "stream": "simple_stream", "record": {"id": "2", "client_name": "Gitter iOS App"}}

--- a/target_mssql/tests/test_core.py
+++ b/target_mssql/tests/test_core.py
@@ -199,3 +199,13 @@ def test_large_int(mssql_target):
 def test_db_schema(mssql_target):
     file_name = "target_schema.singer"
     singer_file_to_target(file_name, mssql_target)
+
+
+def test_simple_stream(mssql_target):
+    file_name = "simple_stream.singer"
+    singer_file_to_target(file_name, mssql_target)
+
+
+def test_null_key(mssql_target):
+    file_name = "null_key.singer"
+    singer_file_to_target(file_name, mssql_target)


### PR DESCRIPTION
Turns out identity columns have more to do with auto increment, and sqlalchemy for some reason creates autoincrement by default on numeric index columns. So basically, the troubles with identity columns can be fixed by adding the `autoincrement=False` option when defining key columns.

Also added two tests, because tests are good.