### PR TITLE
converting objects/arrays to string so that they can be loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ plugins/
 config.json
 poetry.lock
 .dccache
+_jottings.py

--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -360,7 +360,7 @@ class mssqlConnector(SQLConnector):
             return cast(sqlalchemy.types.TypeEngine, mssql.VARCHAR(1))
 
         if self._jsonschema_type_check(jsonschema_type, ("object",)):
-            return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.JSON())
+            return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.VARCHAR())
 
         if self._jsonschema_type_check(jsonschema_type, ("array",)):
             return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.JSON())

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -9,7 +9,7 @@ import sqlalchemy
 from singer_sdk.helpers._conformers import replace_leading_digit
 from singer_sdk.sinks import SQLSink
 from sqlalchemy import Column
-
+import json
 from target_mssql.connector import mssqlConnector
 
 
@@ -64,8 +64,8 @@ class mssqlSink(SQLSink):
         """
         keys = record.keys()
         for key in keys:
-            if type(record[key]) is list:
-                record[key] = str(record[key])
+            if type(record[key]) in [list, dict]:
+                record[key] = json.dumps(record[key], default=str)
 
         return record
 

--- a/target_mssql/tests/data_files/column_comments.singer
+++ b/target_mssql/tests/data_files/column_comments.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "column_comments", "schema": {"required": ["id"], "type": "object", "properties": { "id": {"type": ["string", "null"], "description": "System ID of the client"}, "client_name": {"type": "string", "description": "The name of the client"} }}, "key_properties": ["id"]}
+{"type": "RECORD", "stream": "column_comments", "record": {"id": "1", "client_name": "Gitter Windows Desktop App"}}
+{"type": "RECORD", "stream": "column_comments", "record": {"id": "2", "client_name": "Gitter iOS App"}}

--- a/target_mssql/tests/data_files/disappearing_columns.singer
+++ b/target_mssql/tests/data_files/disappearing_columns.singer
@@ -1,0 +1,6 @@
+{"type": "SCHEMA", "stream": "disappearing_columns", "schema": {"required": ["id"], "type": "object", "properties": { "id": {"type": ["string", "null"], "description": "System ID of the client"}, "client_name": {"type": "string", "description": "The name of the client"}, "client_details": {"type": "string", "description": "The details of the client"} }}, "key_properties": ["id"]}
+{"type": "RECORD", "stream": "disappearing_columns", "record": {"id": "1", "client_name": "Gitter Windows Desktop App", "client_details": "An application for windows"}}
+{"type": "RECORD", "stream": "disappearing_columns", "record": {"id": "2", "client_name": "Gitter iOS App", "client_details": "An application for iOS"}}
+{"type": "SCHEMA", "stream": "disappearing_columns", "schema": {"required": ["id"], "type": "object", "properties": { "id": {"type": ["string", "null"], "description": "System ID of the client"}, "client_name": {"type": "string", "description": "The name of the client"} }}, "key_properties": ["id"]}
+{"type": "RECORD", "stream": "disappearing_columns", "record": {"id": "3", "client_name": "Mirror Android app"}}
+{"type": "RECORD", "stream": "disappearing_columns", "record": {"id": "4", "client_name": "Mirror Webapp"}}

--- a/target_mssql/tests/data_files/schema_no_properties.singer
+++ b/target_mssql/tests/data_files/schema_no_properties.singer
@@ -1,6 +1,6 @@
 {"type": "SCHEMA", "stream": "test_object_schema_with_properties", "key_properties": [], "schema": {"type": "object", "properties": { "object_store": {"type": "object", "properties": {"id": {"type": "integer"}, "metric": {"type": "integer"}}}}}}
 {"type": "RECORD", "stream": "test_object_schema_with_properties", "record": {"object_store": {"id": 1, "metric": 187}}}
 {"type": "RECORD", "stream": "test_object_schema_with_properties", "record": {"object_store": {"id": 2, "metric": 203}}}
-{"type": "SCHEMA", "stream": "test_object_schema_no_properties", "key_properties": [], "schema": {"type": "object", "properties": { "object_store": {"type": "object"}}}}
+{"type": "SCHEMA", "stream": "test_object_schema_no_properties", "key_properties": [], "schema": {"type": "object"}}
 {"type": "RECORD", "stream": "test_object_schema_no_properties", "record": {"object_store": {"id": 1, "metric": 1}}}
 {"type": "RECORD", "stream": "test_object_schema_no_properties", "record": {"object_store": {"id": 2, "metric": 2}}}

--- a/target_mssql/tests/test_core.py
+++ b/target_mssql/tests/test_core.py
@@ -63,7 +63,7 @@ def test_countries_to_mssql(mssql_config):
     sync_end_to_end(tap, target)
 
 
-@pytest.mark.skip("Can't handle objects yet")
+#@pytest.mark.skip("Can't handle objects yet")
 def test_table(mssql_config):
     tap = Fundamentals(config={}, state=None)
     target = Targetmssql(config=mssql_config)
@@ -107,7 +107,7 @@ def test_column_camel_case(mssql_target):
 
 
 # TODO test that data is correctly set
-@pytest.mark.skip(reason="Waiting for SDK to handle this")
+#@pytest.mark.skip(reason="Waiting for SDK to handle this")
 def test_special_chars_in_attributes(mssql_target):
     file_name = "special_chars_in_attributes.singer"
     singer_file_to_target(file_name, mssql_target)
@@ -175,13 +175,13 @@ def test_encoded_string_data(mssql_target):
     singer_file_to_target(file_name, mssql_target)
 
 
-@pytest.mark.skip(reason="Can't handle objects yet")
+#@pytest.mark.skip(reason="Can't handle objects yet")
 def test_tap_appl(mssql_target):
     file_name = "tap_aapl.singer"
     singer_file_to_target(file_name, mssql_target)
 
 
-@pytest.mark.skip(reason="TODO")
+#@pytest.mark.skip(reason="TODO")
 def test_tap_countries(mssql_target):
     file_name = "tap_countries.singer"
     singer_file_to_target(file_name, mssql_target)
@@ -221,4 +221,9 @@ def test_simple_continents(mssql_target):
 @pytest.mark.skip(reason="TODO")
 def test_simple_countries(mssql_target):
     file_name = "simple_countries.singer"
+    singer_file_to_target(file_name, mssql_target)
+
+
+def test_disappearing_columns(mssql_target):
+    file_name = "disappearing_columns.singer"
     singer_file_to_target(file_name, mssql_target)


### PR DESCRIPTION
Instead of failing on objects/arrays, we now convert them to strings. SQL Server is quite OK with querying strings as JSON, so this is a decent improvement.

Sqlalchemy has a little trouble inserting objects, so this is probably the best alternative for the time being.