### PR TITLE
Bigint

### DIFF
--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -349,7 +349,7 @@ class mssqlConnector(SQLConnector):
             )
 
         if self._jsonschema_type_check(jsonschema_type, ("integer",)):
-            return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.INTEGER())
+            return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.BIGINT())
         if self._jsonschema_type_check(jsonschema_type, ("number",)):
             return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.NUMERIC(22, 16))
         if self._jsonschema_type_check(jsonschema_type, ("boolean",)):


### PR DESCRIPTION
Use BIGINT datatype by default so that it handles larger integers.