### PR TITLE
Upgrade to latest compatible SDK version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.12"
 requests = "^2.25.1"
-singer-sdk = "^0.19"
+singer-sdk = "^0.34"
 pymssql = ">=2.2.5"
 sqlalchemy = "^1.4"
 

--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Dict, Iterable, List, Optional, cast
 
 import sqlalchemy
@@ -395,3 +396,7 @@ class mssqlConnector(SQLConnector):
         """  # nosec
 
         self.connection.execute(ddl)
+
+    @cached_property
+    def connection(self):
+        return self._engine.connect().execution_options(stream_results=True)


### PR DESCRIPTION
Tested locally against an Azure Container Instance and working fine.

Unit tests are failing but they don't seem to pass prior to this change either - maybe I'm missing some configuration?

```
>   ???
E   pymssql._mssql.MSSQLDatabaseException: (20009, b'DB-Lib error message 20009, severity 9:\nUnable to connect: Adaptive Server is unavailable or does not exist (localhost)\nNet-Lib error during Connection refused (111)\nDB-Lib error message 20009, severity 9:\nUnable to connect: Adaptive Server is unavailable or does not exist (localhost)\nNet-Lib error during Connection refused (111)\n')

src/pymssql/_mssql.pyx:1898: MSSQLDatabaseException
```